### PR TITLE
Improved handling of bash arguments and versioning

### DIFF
--- a/subworkflows/automate_input/bin/check_samplesheet.py
+++ b/subworkflows/automate_input/bin/check_samplesheet.py
@@ -10,9 +10,8 @@ import argparse
 
 def parse_args(args=None):
     Description = "Reformat nf-core/readmapping samplesheet file and check its contents."
-    Epilog = "Example usage: python check_samplesheet.py <FILE_IN> <FILE_OUT>"
 
-    parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
+    parser = argparse.ArgumentParser(description=Description)
     parser.add_argument("FILE_IN", help="Input samplesheet file.")
     parser.add_argument("FILE_OUT", help="Output file.")
     return parser.parse_args(args)

--- a/subworkflows/automate_input/bin/check_samplesheet.py
+++ b/subworkflows/automate_input/bin/check_samplesheet.py
@@ -14,6 +14,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(description=Description)
     parser.add_argument("FILE_IN", help="Input samplesheet file.")
     parser.add_argument("FILE_OUT", help="Output file.")
+    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
     return parser.parse_args(args)
 
 

--- a/subworkflows/automate_input/bin/tol_input.sh
+++ b/subworkflows/automate_input/bin/tol_input.sh
@@ -4,9 +4,9 @@ PROJECT_BASEDIR=/lustre/scratch124/tol/projects
 
 if [ $# -ne 2 ]; then echo -e "Please provide a ToL ID and a project. \nUsage: ./automate_io <tol_id> <tol_project>. \n<tol_id> must match the expected genome."; exit 1; fi
 
-id=$1
-project=$2
-data=$PROJECT_BASEDIR/$project/data
+id="$1"
+project="$2"
+data="$PROJECT_BASEDIR/$project/data"
 
 if [[ ! -d "$data" ]]
 then

--- a/subworkflows/automate_input/bin/tol_input.sh
+++ b/subworkflows/automate_input/bin/tol_input.sh
@@ -31,5 +31,5 @@ else echo "No cram files."; exit 1; fi
 
 if compgen -G $analysis/assembly/indices/${gca}.unmasked.fasta > /dev/null
     then cp $analysis/assembly/indices/${gca}.unmasked.fasta ./
-else "Unmasked fasta does not exist."; exit 1; fi
+else echo "Unmasked fasta does not exist."; exit 1; fi
 

--- a/subworkflows/automate_input/bin/tol_input.sh
+++ b/subworkflows/automate_input/bin/tol_input.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
+PROJECT_BASEDIR=/lustre/scratch124/tol/projects
+
 if [ $# -ne 2 ]; then echo -e "Please provide a ToL ID and a project. \nUsage: ./automate_io <tol_id> <tol_project>. \n<tol_id> must match the expected genome."; exit 1; fi
 
 id=$1
 project=$2
-data=/lustre/scratch124/tol/projects/$project/data
+data=$PROJECT_BASEDIR/$project/data
+
+if [[ ! -d "$data" ]]
+then
+    echo "Project "$project" cannot be found under $PROJECT_BASEDIR"
+    exit 1
+fi
 
 if compgen -G $data/*/*/assembly/release/${id}.[0-9]/insdc/GCA*fasta.gz > /dev/null
     then genome=$(ls $data/*/*/assembly/release/${id}.[0-9]/insdc/GCA*fasta.gz | tail -1)
 elif compgen -G $data/*/*/assembly/release/${id}.[0-9]_{p,m}aternal_haplotype/insdc/GCA*fasta.gz > /dev/null
     then genome=$(ls $data/*/*/assembly/release/${id}.[0-9]_*aternal_haplotype/insdc/GCA*fasta.gz | tail -1)
-else echo "Genome for $id not found"; exit 1; fi
+else echo "Genome for $id not found in $data"; exit 1; fi
 
 taxon=$(echo $genome | cut -f8 -d'/')
 organism=$(echo $genome | cut -f9 -d'/')

--- a/subworkflows/automate_input/bin/tol_input.sh
+++ b/subworkflows/automate_input/bin/tol_input.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]; then echo -e "Please provide a ToL ID. \nUsage: ./automate_io <tol_id> <tol_project>. \n<tol_id> must match the expected genome. \n<tol_project> defaults to 'darwin'."; exit 1; fi
+if [ $# -ne 2 ]; then echo -e "Please provide a ToL ID and a project. \nUsage: ./automate_io <tol_id> <tol_project>. \n<tol_id> must match the expected genome."; exit 1; fi
 
 id=$1
 project=$2

--- a/subworkflows/automate_input/bin/tol_input.sh
+++ b/subworkflows/automate_input/bin/tol_input.sh
@@ -2,7 +2,7 @@
 
 PROJECT_BASEDIR=/lustre/scratch124/tol/projects
 
-if [ $# -ne 2 ]; then echo -e "Please provide a ToL ID and a project. \nUsage: ./automate_io <tol_id> <tol_project>. \n<tol_id> must match the expected genome."; exit 1; fi
+if [ $# -ne 2 ]; then echo -e "Script to create a samplesheet for a species.\nUsage: $0 <tol_id> <tol_project>.\nVersion: 1.0"; exit 1; fi
 
 id="$1"
 project="$2"

--- a/subworkflows/automate_input/modules/local/input_tol.nf
+++ b/subworkflows/automate_input/modules/local/input_tol.nf
@@ -1,5 +1,5 @@
 process INPUT_TOL {
-    label 'process_nompi'
+    label 'process_single'
 
     conda (params.enable_conda ? "conda-forge::gawk=5.1.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/subworkflows/automate_input/modules/local/input_tol.nf
+++ b/subworkflows/automate_input/modules/local/input_tol.nf
@@ -18,7 +18,7 @@ process INPUT_TOL {
     task.ext.when == null || task.ext.when
 
     script:
-    def proj = project ? "${project}" : ""
+    def proj = project ?: ""
     """
     tol_input.sh $tolid ${proj}
 

--- a/subworkflows/automate_input/modules/local/input_tol.nf
+++ b/subworkflows/automate_input/modules/local/input_tol.nf
@@ -24,7 +24,7 @@ process INPUT_TOL {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        GNU Awk: \$(echo \$(awk --version 2>&1) | grep -i awk | sed 's/GNU Awk //; s/,.*//')
+        tol_input.sh: \$(tol_input.sh | tail -n 1 | cut -d' ' -f2)
     END_VERSIONS
     """
 }

--- a/subworkflows/automate_input/modules/local/input_tol.nf
+++ b/subworkflows/automate_input/modules/local/input_tol.nf
@@ -20,7 +20,7 @@ process INPUT_TOL {
     script:
     def proj = project ?: ""
     """
-    tol_input.sh $tolid ${proj}
+    tol_input.sh "$tolid" "$proj"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/automate_input/modules/local/samplesheet_check.nf
+++ b/subworkflows/automate_input/modules/local/samplesheet_check.nf
@@ -21,7 +21,7 @@ process SAMPLESHEET_CHECK {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
+        check_samplesheet.py: \$(check_samplesheet.py --version | cut -d' ' -f2)
     END_VERSIONS
     """
 }


### PR DESCRIPTION
As I started working on the versions the Nextflow modules report ( https://jira.sanger.ac.uk/browse/TOLIT-650 ), I've made a few changes to address issues that were raised in the GitHub discussion on the handling of the bash arguments.

This PR is essentially a collection of individual changes, each has an explanation in its commit message. There's still something I'd like to explain.

Following up on what we discussed this morning, I checked how the arguments made it from Nextflow to bash. I haven't tried `$task.ext.args` yet, but the existing `$proj` and `$tolid` arguments are by default passed unquoted, and would be split if they include a whitespace. For instance, if `$proj` is `darwin with space`, the bash script will receive `darwin` as `$2`, `with` as `$3`, etc. Even though we're not planning to have whitespace in paths, and many other things would likely break, I'm still suggesting here to properly quote the arguments as much as we can, and ensure the variables are what they're meant to be. 