### PR TITLE
Optimised resources

### DIFF
--- a/subworkflows/prepare_fasta/README.md
+++ b/subworkflows/prepare_fasta/README.md
@@ -30,5 +30,6 @@ Currently to integrate this subworkflow into an nf-core pipeline:
 
 - Install all three nf-core modules
 - Copy the subworkflow file in
+- Add in `conf/base.config` the highlighted section from `nextflow.config`
 - Add in `conf/modules.config` the highlighted section from `nextflow.config`
 - Connect `PREPARE_FASTA` to a channel of Fasta files

--- a/subworkflows/prepare_fasta/nextflow.config
+++ b/subworkflows/prepare_fasta/nextflow.config
@@ -1,4 +1,4 @@
-// Resource settings - normally provided through pipeline `nextflow.config`
+// Main settings - normally provided through `nextflow.config`
 params {
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2
@@ -19,7 +19,31 @@ singularity.enabled    = true
 singularity.autoMounts = true
 singularity.runOptions = '--bind /lustre --bind /nfs'
 
-// Publishing settings - normally provided through pipeline `conf/modules.config`
+// Resource settings - normally provided through `conf/base.config`
+process {
+
+    // The following must be copied to your `conf/base.config`
+    ///////////////////////////////////////////////////////////////////////////
+    /*
+    // NOTE: Wrap this with a "withName" clause that catches the sub-workflow name
+    // Most of the pipeline requires very little resources
+    cpus   = 1
+    // but still gradually increase the resources to allow the pipeline to self-heal
+    memory = { check_max( 50.MB * task.attempt, 'memory' ) }
+    time   = { check_max( 30.min * task.attempt, 'time' ) }
+    // NOTE END
+
+    // NOTE: Update the clause to match the sub-workflow and module names
+    // samtools dict loads entire sequences in memory
+    withName: 'SAMTOOLS_DICT' {
+        // 50 MB per 50 Mbp
+        memory = { check_max( 50.MB + 50.MB * task.attempt * Math.ceil(meta.max_length / 50000000), 'memory' ) }
+    }
+    */
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+// Publishing settings - normally provided through `conf/modules.config`
 process {
 
     // The following must be copied to your `conf/modules.config`

--- a/subworkflows/prepare_fasta/subworkflows/local/prepare_fasta.nf
+++ b/subworkflows/prepare_fasta/subworkflows/local/prepare_fasta.nf
@@ -24,16 +24,53 @@ workflow PREPARE_FASTA {
     ch_samtools_faidx   = CUSTOM_GETCHROMSIZES (ch_compressed_fasta).fai
     ch_versions         = ch_versions.mix(CUSTOM_GETCHROMSIZES.out.versions)
 
+    // Read the .fai file, extract sequence statistics, and make an extended meta map
+    sequence_map        = ch_samtools_faidx.map {
+        meta, fai -> [meta, meta + get_sequence_map(fai)]
+    }
+    // Update all channels to use the extended meta map
+    fasta_gz            = ch_compressed_fasta.join(sequence_map).map { [it[2], it[1]]}
+    faidx               = ch_samtools_faidx.join(sequence_map).map { [it[2], it[1]]}
+    gzi                 = CUSTOM_GETCHROMSIZES.out.gzi.join(sequence_map).map { [it[2], it[1]]}
+    sizes               = CUSTOM_GETCHROMSIZES.out.sizes.join(sequence_map).map { [it[2], it[1]]}
+    expanded_fasta      = fasta.join(sequence_map).map { [it[2], it[1]]}
+
     // Generate Samtools dictionary
-    ch_samtools_dict    = SAMTOOLS_DICT (fasta).dict
+    ch_samtools_dict    = SAMTOOLS_DICT (expanded_fasta).dict
     ch_versions         = ch_versions.mix(SAMTOOLS_DICT.out.versions)
 
 
     emit:
-    fasta_gz = ch_compressed_fasta       // path: genome.fa.gz
-    faidx    = ch_samtools_faidx         // path: genome.fa.gz.fai
+    fasta_gz = fasta_gz                  // path: genome.fa.gz
+    faidx    = faidx                     // path: genome.fa.gz.fai
     dict     = ch_samtools_dict          // path: genome.fa.dict
-    gzi      = CUSTOM_GETCHROMSIZES.out.gzi     // path: genome.fa.gz.gzi
-    sizes    = CUSTOM_GETCHROMSIZES.out.sizes   // path: genome.fa.gz.sizes
+    gzi      = gzi                       // path: genome.fa.gz.gzi
+    sizes    = sizes                     // path: genome.fa.gz.sizes
     versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
+}
+
+// Read the .fai file to extract the number of sequences, the maximum and total sequence length
+// Inspired from https://github.com/nf-core/rnaseq/blob/3.10.1/lib/WorkflowRnaseq.groovy
+def get_sequence_map(fai_file) {
+    def n_sequences = 0
+    def max_length = 0
+    def total_length = 0
+    fai_file.eachLine { line ->
+        def lspl   = line.split('\t')
+        def chrom  = lspl[0]
+        def length = lspl[1].toInteger()
+        n_sequences ++
+        total_length += length
+        if (length > max_length) {
+            max_length = length
+        }
+    }
+
+    def sequence_map = [:]
+    sequence_map.n_sequences = n_sequences
+    sequence_map.total_length = total_length
+    if (n_sequences) {
+        sequence_map.max_length = max_length
+    }
+    return sequence_map
 }

--- a/subworkflows/prepare_repeats/README.md
+++ b/subworkflows/prepare_repeats/README.md
@@ -29,5 +29,6 @@ Currently to integrate this subworkflow into an nf-core pipeline:
 
 - Install the two nf-core modules
 - Copy the script, the local module, and the subworkflow file in
+- Add in `conf/base.config` the highlighted section from `nextflow.config`
 - Add in `conf/modules.config` the highlighted section from `nextflow.config`
 - Connect `PREPARE_REPEATS` to a channel of Fasta files

--- a/subworkflows/prepare_repeats/bin/repeats_bed.py
+++ b/subworkflows/prepare_repeats/bin/repeats_bed.py
@@ -2,6 +2,7 @@
 # This script was originally conceived by @muffato
 
 import argparse
+import gzip
 import sys
 
 __doc__ = "This script prints a BED file of the masked regions a fasta file."
@@ -10,7 +11,7 @@ __doc__ = "This script prints a BED file of the masked regions a fasta file."
 def fasta_to_bed(fasta):
 
     in_gap = None
-    with open(sys.argv[1]) as fh:
+    with gzip.open(fasta, "rt") if fasta.endswith(".gz") else open(fasta) as fh:
         for line in fh:
             line = line[:-1]
             if line.startswith(">"):
@@ -41,7 +42,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("fasta", help="Input Fasta file.")
-    parser.add_argument("--version", action="version", version="%(prog)s 1.0")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.1")
     args = parser.parse_args()
 
     fasta_to_bed(args.fasta)

--- a/subworkflows/prepare_repeats/nextflow.config
+++ b/subworkflows/prepare_repeats/nextflow.config
@@ -1,4 +1,4 @@
-// Resource settings - normally provided through pipeline `nextflow.config`
+// Main settings - normally provided through `nextflow.config`
 params {
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2
@@ -19,7 +19,24 @@ singularity.enabled    = true
 singularity.autoMounts = true
 singularity.runOptions = '--bind /lustre --bind /nfs'
 
-// Publishing settings - normally provided through pipeline `conf/modules.config`
+// Resource settings - normally provided through `conf/base.config`
+process {
+
+    // The following must be copied to your `conf/base.config`
+    ///////////////////////////////////////////////////////////////////////////
+    /*
+    // NOTE: Wrap this with a "withName" clause that catches the sub-workflow name
+    // Most of the pipeline requires very little resources
+    cpus   = 1
+    // but still gradually increase the resources to allow the pipeline to self-heal
+    memory = { check_max( 50.MB * task.attempt, 'memory' ) }
+    time   = { check_max( 30.min * task.attempt, 'time' ) }
+    // NOTE END
+    */
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+// Publishing settings - normally provided through `conf/modules.config`
 process {
 
     // The following must be copied to your `conf/modules.config`

--- a/subworkflows/prepare_repeats/subworkflows/local/prepare_repeats.nf
+++ b/subworkflows/prepare_repeats/subworkflows/local/prepare_repeats.nf
@@ -26,10 +26,17 @@ workflow PREPARE_REPEATS {
     ch_compressed_bed   = TABIX_BGZIP ( ch_bed ).output
     ch_versions         = ch_versions.mix(TABIX_BGZIP.out.versions)
 
-    // Index the BED file in two formats for maximum compatibility
-    ch_indexed_bed_csi  = TABIX_TABIX_CSI ( ch_compressed_bed ).csi
+    // Try indexing the BED file in two formats for maximum compatibility
+    // but each has its own limitations
+    tabix_selector      = ch_compressed_bed.branch { meta, bed ->
+        tbi_and_csi: meta.max_length < 2**29
+        only_csi:    meta.max_length < 2**32
+    }
+
+    // Do the indexing on the compatible Fasta files
+    ch_indexed_bed_csi  = TABIX_TABIX_CSI ( tabix_selector.tbi_and_csi.mix(tabix_selector.only_csi) ).csi
     ch_versions         = ch_versions.mix(TABIX_TABIX_CSI.out.versions)
-    ch_indexed_bed_tbi  = TABIX_TABIX_TBI ( ch_compressed_bed ).tbi
+    ch_indexed_bed_tbi  = TABIX_TABIX_TBI ( tabix_selector.tbi_and_csi ).tbi
     ch_versions         = ch_versions.mix(TABIX_TABIX_TBI.out.versions)
 
 

--- a/subworkflows/prepare_repeats/subworkflows/local/prepare_repeats.nf
+++ b/subworkflows/prepare_repeats/subworkflows/local/prepare_repeats.nf
@@ -31,7 +31,13 @@ workflow PREPARE_REPEATS {
     tabix_selector      = ch_compressed_bed.branch { meta, bed ->
         tbi_and_csi: meta.max_length < 2**29
         only_csi:    meta.max_length < 2**32
+        no_tabix:    true
     }
+
+    // Output channels to tell the downstream subworkflows which indexes are missing
+    // (therefore, only meta is available)
+    no_csi              = tabix_selector.no_tabix.map {it[0]}
+    no_tbi              = tabix_selector.only_csi.mix(tabix_selector.no_tabix).map {it[0]}
 
     // Do the indexing on the compatible Fasta files
     ch_indexed_bed_csi  = TABIX_TABIX_CSI ( tabix_selector.tbi_and_csi.mix(tabix_selector.only_csi) ).csi
@@ -44,5 +50,7 @@ workflow PREPARE_REPEATS {
     bed_gz   = ch_compressed_bed            // path: genome.bed.gz
     bed_csi  = ch_indexed_bed_csi           // path: genome.bed.gz.csi
     bed_tbi  = ch_indexed_bed_tbi           // path: genome.bed.gz.tbi
+    no_csi   = no_csi                       // (only meta)
+    no_tbi   = no_tbi                       // (only meta)
     versions = ch_versions.ifEmpty(null)    // channel: [ versions.yml ]
 }


### PR DESCRIPTION
I ran on the LSF farm the [sanger-tol/insdcdownload](https://github.com/sanger-tol/insdcdownload), [sanger-tol/ensemblrepeatdownload](https://github.com/sanger-tol/ensemblrepeatdownload) and [sanger-tol/ensemblgenedownload](https://github.com/sanger-tol/ensemblgenedownload) pipelines on sample-sheets that contain *every* ToL assembly. I then used the execution_report file to find out failures and the memory consumption, and come up with two rules:

1. `samtools dict`'s memory usage is the length of the longest sequence of the Fasta file (+ a tiny overhead).
2. We already have assemblies that are too large for `tabix`'s TBI indexing (which is limited to sequences < 2^29 bp), so need to add a check in the sub-workflow.
3. I've also included the [current limitation of `tabix`'s CSI indexing](https://sanger-openstack.slack.com/archives/C419NLP7B/p1673871731110159?thread_ts=1673861100.995689&cid=C419NLP7B): 2^32 bp. Yes, CSI could handle sequences up to 8 Gbp with the extra `-m 15` option, but I haven't researched the implications of using that option, and anyway, current limitations of BAM, CRAM and ENA mean we can't have sequences > 2^32 bp anyway.

To get the maximum sequence length of a Fasta file, I restructured the `prepare_fasta` sub-workflow to load the `.fai` file (which contains the length of every sequence). Thinking ahead of other potential memory usage patterns, I also calculate the number of sequences and the total sequence length. To pass all the information to the processes in the sub-workflow and beyond, I expand the `meta` map, and do so in _every_ output channel for consistency (and to allow further `join`). I decided to parse the `.fai` files in pure Groovy because it's much more practical than an external process, and they're so small they don't incur much load on the Nextflow manager.

Changes related to those three pipelines come here first, because they all use the `prepare_fasta` and `prepare_repeats` sub-workflows which are primarily hosted here. Additionally:

- `repeats_bed.py` now supports compressed Fasta files (that's what allows plugging `prepare_repeats` after `prepare_fasta`)
- I added two output channels in `prepare_repeats`: `no_tbi` and `no_csi` so that the caller could know which assemblies pass those criteria
- I also provide a sample config file for the memory requirement: all other analyses take very little RAM, and I decided to request memory by 50 MB increments